### PR TITLE
feat(weex): support init and reset timer functions of next-tick

### DIFF
--- a/src/core/util/next-tick.js
+++ b/src/core/util/next-tick.js
@@ -3,7 +3,7 @@
 
 import { noop } from 'shared/util'
 import { handleError } from './error'
-import { isIOS, isNative } from './env'
+import { isIOS, isNative, inWeex } from './env'
 
 const callbacks = []
 let pending = false
@@ -29,49 +29,60 @@ let microTimerFunc
 let macroTimerFunc
 let useMacroTask = false
 
-// Determine (macro) task defer implementation.
-// Technically setImmediate should be the ideal choice, but it's only available
-// in IE. The only polyfill that consistently queues the callback after all DOM
-// events triggered in the same loop is by using MessageChannel.
-/* istanbul ignore if */
-if (typeof setImmediate !== 'undefined' && isNative(setImmediate)) {
-  macroTimerFunc = () => {
-    setImmediate(flushCallbacks)
+export function initTimerFunc () {
+  // Determine (macro) task defer implementation.
+  // Technically setImmediate should be the ideal choice, but it's only available
+  // in IE. The only polyfill that consistently queues the callback after all DOM
+  // events triggered in the same loop is by using MessageChannel.
+  /* istanbul ignore if */
+  if (typeof setImmediate !== 'undefined' && isNative(setImmediate)) {
+    macroTimerFunc = () => {
+      setImmediate(flushCallbacks)
+    }
+  } else if (typeof MessageChannel !== 'undefined' && (
+    isNative(MessageChannel) ||
+    // PhantomJS
+    MessageChannel.toString() === '[object MessageChannelConstructor]'
+  )) {
+    const channel = new MessageChannel()
+    const port = channel.port2
+    channel.port1.onmessage = flushCallbacks
+    macroTimerFunc = () => {
+      port.postMessage(1)
+    }
+  } else {
+    /* istanbul ignore next */
+    macroTimerFunc = () => {
+      setTimeout(flushCallbacks, 0)
+    }
   }
-} else if (typeof MessageChannel !== 'undefined' && (
-  isNative(MessageChannel) ||
-  // PhantomJS
-  MessageChannel.toString() === '[object MessageChannelConstructor]'
-)) {
-  const channel = new MessageChannel()
-  const port = channel.port2
-  channel.port1.onmessage = flushCallbacks
-  macroTimerFunc = () => {
-    port.postMessage(1)
-  }
-} else {
-  /* istanbul ignore next */
-  macroTimerFunc = () => {
-    setTimeout(flushCallbacks, 0)
+
+  // Determine microtask defer implementation.
+  /* istanbul ignore next, $flow-disable-line */
+  if (typeof Promise !== 'undefined' && isNative(Promise)) {
+    const p = Promise.resolve()
+    microTimerFunc = () => {
+      p.then(flushCallbacks)
+      // in problematic UIWebViews, Promise.then doesn't completely break, but
+      // it can get stuck in a weird state where callbacks are pushed into the
+      // microtask queue but the queue isn't being flushed, until the browser
+      // needs to do some other work, e.g. handle a timer. Therefore we can
+      // "force" the microtask queue to be flushed by adding an empty timer.
+      if (!inWeex && isIOS) setTimeout(noop)
+    }
+  } else {
+    // fallback to macro
+    microTimerFunc = macroTimerFunc
   }
 }
+initTimerFunc()
 
-// Determine microtask defer implementation.
-/* istanbul ignore next, $flow-disable-line */
-if (typeof Promise !== 'undefined' && isNative(Promise)) {
-  const p = Promise.resolve()
-  microTimerFunc = () => {
-    p.then(flushCallbacks)
-    // in problematic UIWebViews, Promise.then doesn't completely break, but
-    // it can get stuck in a weird state where callbacks are pushed into the
-    // microtask queue but the queue isn't being flushed, until the browser
-    // needs to do some other work, e.g. handle a timer. Therefore we can
-    // "force" the microtask queue to be flushed by adding an empty timer.
-    if (isIOS) setTimeout(noop)
-  }
-} else {
-  // fallback to macro
-  microTimerFunc = macroTimerFunc
+export function resetTimerFunc () {
+  callbacks.length = 0
+  pending = false
+  microTimerFunc = null
+  macroTimerFunc = null
+  useMacroTask = false
 }
 
 /**
@@ -102,10 +113,12 @@ export function nextTick (cb?: Function, ctx?: Object) {
   })
   if (!pending) {
     pending = true
-    if (useMacroTask) {
+    if (useMacroTask && typeof macroTimerFunc === 'function') {
       macroTimerFunc()
-    } else {
+    } else if (typeof microTimerFunc === 'function') {
       microTimerFunc()
+    } else {
+      setTimeout(flushCallbacks, 0)
     }
   }
   // $flow-disable-line

--- a/src/platforms/weex/runtime/index.js
+++ b/src/platforms/weex/runtime/index.js
@@ -14,6 +14,11 @@ import {
   isUnknownElement
 } from 'weex/util/element'
 
+import internalMixin from './mixin'
+
+// register internal mixin
+Vue.mixin(internalMixin)
+
 // install platform specific utils
 Vue.config.mustUseProp = mustUseProp
 Vue.config.isReservedTag = isReservedTag

--- a/src/platforms/weex/runtime/mixin.js
+++ b/src/platforms/weex/runtime/mixin.js
@@ -1,0 +1,24 @@
+/* @flow */
+/**
+ * Internal mixin of Weex.
+ */
+import { initTimerFunc, resetTimerFunc } from 'core/util/next-tick'
+
+function isRootComponent (vm: Component): boolean {
+  return !!(vm.$options && vm.$options.el)
+}
+
+export default {
+  beforeCreate () {
+    // only affect root component
+    if (isRootComponent(this)) {
+      initTimerFunc()
+    }
+  },
+  destroyed () {
+    // only affect root component
+    if (isRootComponent(this)) {
+      resetTimerFunc()
+    }
+  }
+}


### PR DESCRIPTION
* Stop using setTimeout(noop) to flush task queue in weex.
* Init and reset timer functions of nextTick at beforeCreate and destroyed lifecycles of each weex page.
